### PR TITLE
Apparently `Mick` is a derogatory word for Irish people. Unfortunatel…

### DIFF
--- a/config/profanities.php
+++ b/config/profanities.php
@@ -765,7 +765,6 @@ return array(
     'meatrack',
     'mgger',
     'mggor',
-    'mick',
     'milf',
     'minge',
     'mofo',

--- a/spec/mofodojodino/ProfanityFilter/CheckSpec.php
+++ b/spec/mofodojodino/ProfanityFilter/CheckSpec.php
@@ -152,4 +152,9 @@ class CheckSpec extends ObjectBehavior
     {
         $this->hasProfanity("anthony")->shouldReturn(false);
     }
+
+    public function it_does_not_detect_mick_as_a_swear_word()
+    {
+        $this->hasProfanity("Mick")->shouldReturn(false);
+    }
 }


### PR DESCRIPTION
…y it is also the short version of Michael so I'm removing it from the list of swear words. If any Irish people find this offensive please accept my apologies.